### PR TITLE
Cambio MIDDLEWARE_CLASSES

### DIFF
--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -40,7 +40,8 @@ INSTALLED_APPS = [
     'blog',
 ]
 
-MIDDLEWARE = [
+#MIDDLEWARE = [
+MIDDLEWARE_CLASSES = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
En pythonanywhere.com no funciona la opc /admin/ y la solucion es cambiar MIDDLEWARE por MIDDLEWARE_CLASSES.